### PR TITLE
Add user id to api requests

### DIFF
--- a/examples/v3/find-direct-train.js
+++ b/examples/v3/find-direct-train.js
@@ -15,9 +15,9 @@ function askQuestion(query) {
 }
 
 async function main() {
-  const { UZ_ACCESS_TOKEN } = process.env
+  const { UZ_ACCESS_TOKEN, UZ_USER_ID } = process.env
 
-  const uzClient = new UzClientV3('uk', UZ_ACCESS_TOKEN)
+  const uzClient = new UzClientV3('uk', UZ_ACCESS_TOKEN, undefined, UZ_USER_ID)
 
   if (!UZ_ACCESS_TOKEN) {
     const phoneNumber = await askQuestion('Your phone number: ')

--- a/examples/v3/find-station.js
+++ b/examples/v3/find-station.js
@@ -14,9 +14,9 @@ const askQuestion = (query) => {
 }
 
 const main = async () => {
-  const { UZ_ACCESS_TOKEN } = process.env
+  const { UZ_ACCESS_TOKEN, UZ_USER_ID } = process.env
 
-  const uzClient = new UzClientV3('uk', UZ_ACCESS_TOKEN)
+  const uzClient = new UzClientV3('uk', UZ_ACCESS_TOKEN, undefined, UZ_USER_ID)
 
   if (!UZ_ACCESS_TOKEN) {
     const phoneNumber = await askQuestion('Your phone number: ')
@@ -30,7 +30,7 @@ const main = async () => {
 
   const foundStations = await uzClient.Station.find('льв')
 
-  console.dir(foundStations.data, { depth: 20, colors: true })
+  console.dir(foundStations, { depth: 20, colors: true })
 }
 
 main()

--- a/examples/v3/list-wagons.js
+++ b/examples/v3/list-wagons.js
@@ -15,9 +15,9 @@ const askQuestion = (query) => {
 }
 
 async function main() {
-  const { UZ_ACCESS_TOKEN } = process.env
+  const { UZ_ACCESS_TOKEN, UZ_USER_ID } = process.env
 
-  const uzClient = new UzClientV3('uk', UZ_ACCESS_TOKEN)
+  const uzClient = new UzClientV3('uk', UZ_ACCESS_TOKEN, undefined, UZ_USER_ID)
 
   if (!UZ_ACCESS_TOKEN) {
     const phoneNumber = await askQuestion('Your phone number: ')

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "uz-booking-client",
-  "version": "2.0.0",
+  "name": "@spasea/uz-booking-client",
+  "version": "2.0.1",
   "description": "Unofficial UZ api client",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -13,7 +13,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/DmytryS/uz-booking-api.git"
+    "url": "git+https://github.com/spasea/uz-booking-api.git"
   },
   "keywords": [
     "UZ",
@@ -21,12 +21,12 @@
     "REST",
     "client"
   ],
-  "author": "Dmytro Shvaika",
+  "author": "spasea",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/DmytryS/uz-booking-api/issues"
+    "url": "https://github.com/spasea/uz-booking-api/issues"
   },
-  "homepage": "https://github.com/DmytryS/uz-booking-api#readme",
+  "homepage": "https://github.com/spasea/uz-booking-api#readme",
   "dependencies": {
     "@types/node": "20.3.1",
     "axios": "1.4.0",
@@ -43,5 +43,8 @@
     "moment": "2.29.4",
     "readline": "^1.3.0",
     "typescript": "5.1.3"
+  },
+  "directories": {
+    "example": "examples"
   }
 }

--- a/src/lib/requestable.ts
+++ b/src/lib/requestable.ts
@@ -42,6 +42,7 @@ export default class Requestable {
   public apiBase: string
   public auth: string
   public lang: string
+  public userId: string | number
   public METHODS_WITH_NO_BODY = ['GET', 'HEAD', 'DELETE']
 
   /**
@@ -50,12 +51,14 @@ export default class Requestable {
    * @param {Object} [auth] - the credentials to authenticate to Github. If auth is
    *                                  not provided request will be made unauthenticated
    * @param {string} [apiBase] - the base UzBooking API URL
-   * @param {boolen} [langAsApiPrefix] - use language in url as prefix
+   * @param {boolean} [langAsApiPrefix] - use language in url as prefix
+   * @param userId
    */
-  constructor(lang: string, auth: string, apiBase: string, langAsApiPrefix = false) {
+  constructor(lang: string, auth: string, apiBase: string, langAsApiPrefix = false, userId: string | number = 'guest') {
     this.apiBase = `${apiBase}${langAsApiPrefix ? lang + '/' : ''}`
     this.lang = lang
     this.auth = auth
+    this.userId = userId
   }
 
   /**
@@ -101,8 +104,9 @@ export default class Requestable {
       // 'User-Agent':
       //   'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.102 Safari/537.36',
       // 'X-Requested-With': 'XMLHttpRequest'
-      'User-Agent': 'UZ/1.7.3 Android/7.1.2 User/guest',//'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/94.0.4606.81 Safari/537.36',
+      'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/134.0.0.0 Safari/537.36',
       'x-client-locale': this.lang,
+      'x-user-agent': `UZ/2 Web/1 User/${this.userId}`,
     }
 
     return headers

--- a/src/v3/auth.ts
+++ b/src/v3/auth.ts
@@ -14,8 +14,9 @@ export default class Auth extends Requestable {
    * @constructor
    * @param {string} fcmToken
    * @param {string} deviceName
-   * @param {auth} [auth] - the credentials to authenticate to UzBoojking. If auth is
+   * @param {auth} accessToken - the credentials to authenticate to UzBoojking. If auth is
    *                                  not provided requests will be made unauthenticated
+   * @param userId - user id of UZ account
    * @param {Language} [lang] - language
    * @param {string} [apiBase] - the base UzBooking API URL
    */
@@ -23,10 +24,11 @@ export default class Auth extends Requestable {
     fcmToken: string,
     deviceName: string,
     accessToken: string,
-    lang = Language.EN,
+    userId: number | string,
+    lang: Language = Language.EN,
     apiBase: string,
   ) {
-    super(lang, undefined, apiBase)
+    super(lang, undefined, apiBase, false, userId)
 
     this._accessToken = accessToken.replace('Bearer ', '')
     this.fcmToken = fcmToken
@@ -84,6 +86,7 @@ export default class Auth extends Requestable {
 
     if (authResponse) {
       this._accessToken = authResponse.data?.token?.access_token
+      this.userId = authResponse.data?.profile?.id
 
       if (callback) {
         return callback(undefined, authResponse.data?.token, authResponse)

--- a/src/v3/index.ts
+++ b/src/v3/index.ts
@@ -17,6 +17,7 @@ export default class UZ {
    * @param {string} [auth] - the credentials to authenticate to UzBooking. If auth token is
    *                          not provided requests will be made unauthenticated
    * @param {string} [fcmToken]
+   * @param userId
    * @param {string} [deviceName]
    * @param {string} [apiBase='https://app.uz.gov.ua'] - the base UzBooking API URL
    */
@@ -24,6 +25,7 @@ export default class UZ {
     lang: Language,
     auth?: any,
     fcmToken?: string,
+    userId?: number | string,
     deviceName = 'iPhone12.1',
     apiBase = 'https://app.uz.gov.ua',
   ) {
@@ -40,6 +42,7 @@ export default class UZ {
       _fcmToken,
       deviceName,
       auth,
+      userId,
       this.lang,
       this.apiBase,
     )
@@ -58,7 +61,7 @@ export default class UZ {
    * @returns {Station}
    */
   get Station() {
-    return new Station(this.lang, this.authClient.accessToken, this.apiBase)
+    return new Station(this.lang, this.authClient.accessToken, this.apiBase, this.authClient.userId)
   }
 
   /**
@@ -66,7 +69,7 @@ export default class UZ {
    * @returns {Train}
    */
   get Train() {
-    return new Train(this.lang, this.authClient.accessToken, this.apiBase)
+    return new Train(this.lang, this.authClient.accessToken, this.apiBase, this.authClient.userId)
   }
 
   /**
@@ -74,6 +77,6 @@ export default class UZ {
    * @returns {Wagon}
    */
   get Wagon() {
-    return new Wagon(this.lang, this.authClient.accessToken, this.apiBase)
+    return new Wagon(this.lang, this.authClient.accessToken, this.apiBase, this.authClient.userId)
   }
 }

--- a/src/v3/station.ts
+++ b/src/v3/station.ts
@@ -10,9 +10,10 @@ export default class Station extends Requestable {
    * @param {string} lang - language
    * @param {string} auth
    * @param {string} apiBase - the base UzBooking API URL
+   * @param userId
    */
-  constructor(lang: string, auth: any, apiBase: string) {
-    super(lang, auth, apiBase)
+  constructor(lang: string, auth: any, apiBase: string, userId: number | string) {
+    super(lang, auth, apiBase, false, userId)
     this.lang = lang
   }
 

--- a/src/v3/train.ts
+++ b/src/v3/train.ts
@@ -8,9 +8,10 @@ export default class Train extends Requestable {
    * @param {auth} [auth] - the credentials to authenticate to UzBoojking. If auth is
    *                                  not provided requests will be made unauthenticated
    * @param {string} [apiBase] - the base UzBooking API URL
+   * @param userId
    */
-  constructor(lang: string, auth: any, apiBase: string) {
-    super(lang, auth, apiBase)
+  constructor(lang: string, auth: any, apiBase: string, userId: number | string) {
+    super(lang, auth, apiBase, false, userId)
   }
 
   /**

--- a/src/v3/wagon.ts
+++ b/src/v3/wagon.ts
@@ -8,9 +8,10 @@ export default class Wagon extends Requestable {
    * @param {auth} [auth] - the credentials to authenticate to UzBoojking. If auth is
    *                                  not provided requests will be made unauthenticated
    * @param {string} [apiBase] - the base UzBooking API URL
+   * @param userId
    */
-  constructor(lang: string, auth: any, apiBase: string) {
-    super(lang, auth, apiBase)
+  constructor(lang: string, auth: any, apiBase: string, userId: number | string) {
+    super(lang, auth, apiBase, false, userId)
   }
 
   /**


### PR DESCRIPTION
UZ Booking API changed a bit, now it requires `x-user-agent` header with userId being passed (for guest it should be `UZ/2 Web/1 User/guest` and for user it should be `UZ/2 Web/1 User/12345678`)